### PR TITLE
Added CIDR v4 format prefix

### DIFF
--- a/fetch-ripe-assignments.sh
+++ b/fetch-ripe-assignments.sh
@@ -11,7 +11,7 @@ for cc in $countries; do
 	ipv6file="data/$date-$cc-ipv6.txt"
 	asnfile="data/$date-$cc-asn.txt"
 
-	curl "https://stat.ripe.net/data/country-resource-list/data.json?resource=$cc"  > $outfile
+	curl "https://stat.ripe.net/data/country-resource-list/data.json?resource=$cc&v4_format=prefix"  > $outfile
 	jq -r '.data.resources.ipv4[]'  < $outfile > $ipv4file
 	jq -r '.data.resources.ipv6[]'  < $outfile > $ipv6file
 	jq -r '.data.resources.asn[]'   < $outfile > $asnfile


### PR DESCRIPTION
According to the [RIPE stat API documentation](https://stat.ripe.net/docs/data_api#country-resource-list), you need to explicitly declare the `v4_format` parameter to `prefix`. The default `""` returns a combination of CIDR and IP range formats. 

🔗 Previous API request URL without `v4_format` declaration: https://stat.ripe.net/data/country-resource-list/data.json?resource=US

![image](https://user-images.githubusercontent.com/111275753/225542710-af3b5987-183c-4c84-8596-558aab20a778.png)


